### PR TITLE
`.` 命令が変だったので直した

### DIFF
--- a/source/brainfuck/virtualMachine.d
+++ b/source/brainfuck/virtualMachine.d
@@ -102,9 +102,12 @@ class VirtualMachine {
             break;
 
           case 5:
-            string buf;
-            while((buf = readln()) == null || !buf.length){}
-            memory[memoryIndex] = cast(ubyte)buf[0];
+            char[] buf = stdin.rawRead(new char[1]);
+            if (buf.empty) {
+                memory[memoryIndex] = cast(char)(-1);
+            } else {
+                memory[memoryIndex] = buf[0];
+            }
             break;
 
           case 6:
@@ -198,9 +201,12 @@ class VirtualMachine {
           break;
 
         case ',':
-          string buf;
-          while((buf = readln()) == null || !buf.length){}
-          memory[memoryIndex] = cast(ubyte)buf[0];
+          char[] buf = stdin.rawRead(new char[1]);
+          if (buf.empty) {
+              memory[memoryIndex] = cast(char)(-1);
+          } else {
+              memory[memoryIndex] = buf[0];
+          }
           break;
 
         case '[':


### PR DESCRIPTION
`.` 命令は入力からちょうど1文字取得してセルに保存する命令です。
一般的な期待に反する挙動をしていたため修正しました。EOFは-1と定義しておきました。

この修正により正常に動作するようになるプログラムには例えば `,+[-.,+]` (入力をそのまま出力するプログラム) があります。
よろしくお願いします。
